### PR TITLE
Fix/fix macos errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ I have my Plex server listening on directory B for metadata purposes. This autom
 Both scripts do two things:
 
 1. Looks in a directory for files, and for each file the filename will be parsed via Regex, and then moved to a specified directory. You can also choose not to specify a directory by removing the variable `destination` and rename files in bulk in one directory, but #2 will not apply.
-2. When moving the file, the script will check to see the age of the file and if it's at least 10 minutes old. After it checks the file is more than 10 minutes old, it will then check if there exists a directory the specified directory (`destination`). If it exists, the script will move the file over to the matching directory name as the filename. If a directory with the same title as the filename does not exist, the script will create a new directory in the specified directory (`destination`), and move it there. 
+2. When moving the file, the script will check to see the age of the file and if it's at least 10 minutes old. After it checks the file is more than 10 minutes old, it will then check if there exists a directory the specified directory (`destination`). If it exists, the script will move the file over to the matching directory name as the filename. If a directory with the same title as the filename does not exist, the script will create a new directory in the specified directory (`destination`), and move it there.
+
+It will also skip over any files that don't explicitly end with the file formats `.avi`, `.mkv`, or `.mp4`. Will be adding more media file formats to this list going forward.
 
 To download and use, you can install it via:
 `pip install reisen`
@@ -85,7 +87,7 @@ I'm pretty sure this can be done way better than the way I have this written and
 
 ### Add tests
 
-Write stub tests to assert output
+What good is this program if there are no tests to assert what is actually going to be happening? :^)
 
 ### Add automated CI/CD
 
@@ -94,3 +96,7 @@ Plan is to use Jenkins
 ### Add logic to output message if no files are in directories
 
 Currently there is nothing in place to notify the user in the case that there is nothing in the directory
+
+### Refactor code in commands.py
+
+Would be nice to move the logic in the commands.py files and build them out as classes under the `app` folder. Makes it easier to test and maintain. As it is now, it's not very intuitive to follow and read, but it does the job for now.

--- a/app/newAnimeEpisodes.py
+++ b/app/newAnimeEpisodes.py
@@ -96,7 +96,7 @@ class moveFile(object):
                 if not os.path.exists(self.newDir):
                     print (f"\n{colorText('NO DIRECTORY FOUND')[2]}: Creating new directory: {colorText(self.newDir)[1]}")
                     # creates new directory with the new file name within dir2
-                    os.makedirs(self.newDir + "/")
+                    os.makedirs(self.newDir)
                 return self.newDir
             elif self.fileInfo [2] and self.fileInfo[0] < self.fileInfo[1]:
                 print ("\nFile is not old enough - " + colorText('ABORTING')[2])

--- a/generate/commands.py
+++ b/generate/commands.py
@@ -56,7 +56,7 @@ def generate(source, destination, exe):
             if OS == 'Windows':
                 subprocess.call(r'pyinstaller --onefile --add-data "config.ini;." reisen_exec.py')
             elif OS == 'Darwin':
-                subprocess.call(r'pyinstaller --onefile --add-data "config.ini:." reisen_exec.py')
+                subprocess.call('pyinstaller --onefile --add-data "config.ini:." reisen_exec.py', shell=True)
             click.echo(colorText('\nSUCCESS! ')[0] + f'\n\nSingle file executable built and completed. You can find the executable file here:')
             click.echo(colorText(f'\n{execPath}\n')[1])
         else:

--- a/organize/commands.py
+++ b/organize/commands.py
@@ -1,3 +1,4 @@
+from os import path
 import click
 from glob import glob
 from pathlib import Path
@@ -33,14 +34,20 @@ def organize(source, destination, parse, age, move):
             for dir in initialDirGlob:
                 filePath = os.listdir(dir)
                 for originalFileName in filePath:
-                    if originalFileName.endswith( types ):
+                    if os.path.isdir(source + '/' + originalFileName)==False and not originalFileName.endswith( types ):
+                        click.echo(colorText(f'\nERROR: ')[2] + f'Found file that does not end in file types: ')
+                        click.echo(colorText(f'{types}')[1] + '\n')
+                        click.echo(f'Skipping file: ' + colorText(f'{originalFileName}')[1] + '\n')
+                        click.echo('―' * 100)  # U+2015, Horizontal Bar
+                    elif originalFileName.endswith( types ):
                         newFileName = parsedFilename(str(originalFileName)).parse()
                         fileInfo = checkAge(originalFileName, setMinutes, dir).check()
                         runFileActions = moveFile(str(newFileName), str(originalFileName), dir, destination, fileInfo)
                         runFileActions.moveToDir()
-                    elif len(os.listdir(source + '/' + originalFileName)) == 0:
+                    elif os.path.isdir(source + '/' + originalFileName)==True and len(os.listdir(source + '/' + originalFileName)) == 0:
                         click.echo(colorText(f'\nWARNING: ')[2] + f'Found objects that are not video files or empty directories in: ')
                         click.echo(colorText(f'\n{source}\n')[0])
+                        click.echo(f'Files or folders in question: ' + colorText(source + '/' + originalFileName)[1] + '\n      ')
                         click.echo("Please double check your specified base directory and remove any files and/or empty directories that are not video files that match: ")
                         click.echo(colorText(f'{types}')[1] + '\n')
                         click.echo('―' * 100)  # U+2015, Horizontal Bar
@@ -51,12 +58,17 @@ def organize(source, destination, parse, age, move):
             for dir in initialDirGlob:
                 filePath = os.listdir(dir)
                 for originalFileName in filePath:
-                    if originalFileName.endswith( types ):
-                        fileInfo = None
+                    fileInfo = None
+                    if os.path.isdir(source + '/' + originalFileName)==False and not originalFileName.endswith( types ):
+                        click.echo(colorText(f'\nERROR: ')[2] + f'Found file that does not end in file types: ')
+                        click.echo(colorText(f'{types}')[1] + '\n')
+                        click.echo(f'Skipping file: ' + colorText(f'{originalFileName}')[1] + '\n')
+                        click.echo('―' * 100)  # U+2015, Horizontal Bar
+                    elif originalFileName.endswith( types ):
                         newFileName = parsedFilename(str(originalFileName)).parse()
                         runFileActions = moveFile(str(newFileName), str(originalFileName), dir, destination, fileInfo)
                         runFileActions.moveToDir()
-                    elif len(os.listdir(str(source) + '/' + originalFileName)) == 0:
+                    elif os.path.isdir(source + '/' + originalFileName)==True and len(os.listdir(source + '/' + originalFileName)) == 0:
                         click.echo(colorText(f'\nWARNING: ')[2] + f'Found objects that are not video files or empty directories in: ')
                         click.echo(colorText(f'\n{source}\n')[0])
                         click.echo("Please double check your specified base directory and remove any files and/or empty directories that are not video files that match: ")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name='Reisen',
-    version='0.3.9',
+    version='0.4.0',
     author='Joey Wu',
     author_email='joeywu99@gmail.com',
     license = 'MIT',


### PR DESCRIPTION
Some errors were present, namely:

`subprocess.call` was not working as intended on MacOS systems. Adding `shell=True` fixed the issue.

On MacOS, the `reisen organize` command was failing due to it finding `.DS_STORE`. Added logic to skip over files that don't match the extensions defined in `types`, so going forward it should skip over the `.DS_STORE` files and continue moving files instead of exiting with an error.